### PR TITLE
Update RemoteDebug_Basic.ino

### DIFF
--- a/Samples/RemoteDebug_Basic/RemoteDebug_Basic.ino
+++ b/Samples/RemoteDebug_Basic/RemoteDebug_Basic.ino
@@ -93,7 +93,7 @@ void setup() {
 
     // Initialize the telnet server of RemoteDebug
 
-    Debug.begin(); // Initiaze the telnet server
+    Debug.begin(HOST_NAME); // Initiaze the telnet server
 
     Debug.setResetCmdEnabled(true); // Enable the reset command
 


### PR DESCRIPTION
I needed to have a string in Debug.begin() in order for the code to compile in the Arduino IDE in OSX

I get the error without the string:

exit status 1
no matching function for call to 'RemoteDebug::begin()'
