### PR TITLE
Fixed compile error when building with password define enabled.

### DIFF
--- a/RemoteDebug.cpp
+++ b/RemoteDebug.cpp
@@ -465,7 +465,7 @@ boolean RemoteDebug::isActive(uint8_t debugLevel) {
 
 #ifdef REMOTEDEBUG_PASSWORD
 
-	boolean ret = (_PasswordOk &&
+	boolean ret = (_passwordOk &&
 					debugLevel >= _clientDebugLevel &&
 					(_connected || _serialEnabled));
 #else
@@ -755,7 +755,7 @@ void RemoteDebug::showHelp() {
 		help.concat("* Please enter with a password to access");
 #ifdef REMOTEDEBUG_PWD_ATTEMPTS
 		help.concat(" (attempt ");
-		help.concat(_PasswordAttempt);
+		help.concat(_passwordAttempt);
 		help.concat(" of ");
 		help.concat(REMOTEDEBUG_PWD_ATTEMPTS);
 		help.concat(")");
@@ -903,6 +903,7 @@ void RemoteDebug::processCommand() {
 		}
 
 		return;
+	}
 
 	#endif //REMOTEDEBUG_PASSWORD
 

--- a/RemoteDebug.cpp
+++ b/RemoteDebug.cpp
@@ -463,17 +463,8 @@ boolean RemoteDebug::isActive(uint8_t debugLevel) {
 
 	// Password request ? - 04/03/18
 
-#ifdef REMOTEDEBUG_PASSWORD
-
-	boolean ret = (_passwordOk &&
-					debugLevel >= _clientDebugLevel &&
-					(_connected || _serialEnabled));
-#else
-
 	boolean ret = (debugLevel >= _clientDebugLevel &&
 					(_connected || _serialEnabled));
-#endif
-
 	if (ret) {
 		_lastDebugLevel = debugLevel;
 	}
@@ -684,7 +675,11 @@ size_t RemoteDebug::write(uint8_t character) {
 
 			// Send to telnet buffered
 
-			if (_connected) {  // send data to Client
+			if ((_connected) 
+#ifdef REMOTEDEBUG_PASSWORD
+			&& (_passwordOk)
+#endif 
+			){  // send data to Client
 #ifndef CLIENT_BUFFERING
 				TelnetClient.print(_bufferPrint);
 #else // Cliente buffering

--- a/RemoteDebug.h
+++ b/RemoteDebug.h
@@ -47,9 +47,7 @@
 
 // Changed by jeroenst: Password can now be set with the setpassword function
 
-#ifdef REMOTEDEBUG_PASSWORD
-	#define REMOTEDEBUG_PWD_ATTEMPTS 3
-#endif
+#define REMOTEDEBUG_PWD_ATTEMPTS 3
 
 // Maximum time for inactivity (em milliseconds)
 // Default: 10 minutes

--- a/RemoteDebug.h
+++ b/RemoteDebug.h
@@ -45,9 +45,7 @@
 // this kind of authentication will not be done now.
 // Can be by project, just define it before include this file
 
-#ifndef REMOTEDEBUG_PASSWORD
-//#define REMOTEDEBUG_PASSWORD "r3m0t3."
-#endif
+// Changed by jeroenst: Password can now be set with the setpassword function
 
 #ifdef REMOTEDEBUG_PASSWORD
 	#define REMOTEDEBUG_PWD_ATTEMPTS 3
@@ -199,6 +197,8 @@ class RemoteDebug: public Print
 
 	void begin(String hostName, uint16_t port, uint8_t startingDebugLevel = DEBUG);
 	void begin(String hostName, uint8_t startingDebugLevel = DEBUG);
+	
+	void setPassword(String password);
 
 	void stop();
 
@@ -303,10 +303,9 @@ private:
 	uint32_t _lastTimeSend = 0;			// Last time command send data
 #endif
 
-#ifdef REMOTEDEBUG_PASSWORD
-	boolean _passwordOk = false; 		// Password request ? - 18/07/18
+	boolean _passwordOk = false; 		// Password login ok?
 	uint8_t _passwordAttempt = 0;
-#endif
+	String _password = "";
 
 	// Privates
 


### PR DESCRIPTION
- Fix for building error when password is defined
- Serial output will now work when password is enabled
- Password can now be set with .setPassword instead of using defines which makes it possible to change the password in runtime

https://github.com/JoaoLopesF/RemoteDebug/issues/33