### PR TITLE
Remove the WiFiServer.begin begin parameter since it has been removed in the ESP8266 2.3 SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ In the setup function after WiFi initialization
 ```cpp
 // Initialize the telnet server of RemoteDebug
 
-Debug.begin("Telnet_HostName"); // Initiaze the telnet server - this name is used in MDNS.begin
+if (Debug.begin("Telnet_HostName")) {
+  // Initialize the telnet server - this name is used in MDNS.begin
+} 
 
 // OR
 
@@ -183,7 +185,11 @@ Debug.begin(HOST_NAME); // Initiaze the telnet server - HOST_NAME is the used in
 
 // OR
 
-Debug.begin(HOST_NAME, PORT); // Initiaze the telnet server - HOST_NAME is the used in MDNS.begin
+if (Debug.begin(HOST_NAME, PORT)) {
+ // Initiaze the telnet server - HOST_NAME is the used in MDNS.begin
+} else {
+  // Do something since the library unable to start. Most likely because you specified a different port than 22
+}
 
 // OR
 

--- a/RemoteDebug.cpp
+++ b/RemoteDebug.cpp
@@ -93,16 +93,17 @@ WiFiClient TelnetClient;
 
 // Initialize the telnet server
 
-void RemoteDebug::begin(String hostName, uint8_t startingDebugLevel) {
-	begin(hostName, TELNET_PORT, startingDebugLevel);
+bool RemoteDebug::begin(String hostName, uint8_t startingDebugLevel) {
+	return begin(hostName, TELNET_PORT, startingDebugLevel);
 }
 
-void RemoteDebug::begin(String hostName, uint16_t port,  uint8_t startingDebugLevel) {
+bool RemoteDebug::begin(String hostName, uint16_t port,  uint8_t startingDebugLevel) {
 
 	// Initialize server telnet
-	if (port != TELNET_PORT)
-	    throw "Specifying a different port than the default one is not supported";
-
+	if (port != TELNET_PORT) {
+	    return false;
+	}
+	
 	TelnetServer.begin();
 	TelnetServer.setNoDelay(true);
 
@@ -125,7 +126,7 @@ void RemoteDebug::begin(String hostName, uint16_t port,  uint8_t startingDebugLe
 
 	_clientDebugLevel = startingDebugLevel;
 	_lastDebugLevel = startingDebugLevel;
-
+	return true;
 }
 
 // Set the password for telnet - thanks @jeroenst for suggest thist method

--- a/RemoteDebug.cpp
+++ b/RemoteDebug.cpp
@@ -100,8 +100,10 @@ void RemoteDebug::begin(String hostName, uint8_t startingDebugLevel) {
 void RemoteDebug::begin(String hostName, uint16_t port,  uint8_t startingDebugLevel) {
 
 	// Initialize server telnet
+	if (port != TELNET_PORT)
+	    throw "Specifying a different port than the default one is not supported";
 
-	TelnetServer.begin(port);
+	TelnetServer.begin();
 	TelnetServer.setNoDelay(true);
 
 	// Reserve space to buffer of print writes

--- a/RemoteDebug.h
+++ b/RemoteDebug.h
@@ -195,8 +195,8 @@ class RemoteDebug: public Print
 {
 	public:
 
-	void begin(String hostName, uint16_t port, uint8_t startingDebugLevel = DEBUG);
-	void begin(String hostName, uint8_t startingDebugLevel = DEBUG);
+	bool begin(String hostName, uint16_t port, uint8_t startingDebugLevel = DEBUG);
+	bool begin(String hostName, uint8_t startingDebugLevel = DEBUG);
 
 	void setPassword(String password);
 


### PR DESCRIPTION
Updating the SDK to 2.4 make impossible to specify the port rather the constructor. 

To risk less regressions it would be ideal to make this fix only for versions beyond the version. This could be done with a if def, but I would appreciate the help to help me with this.