### PR TITLE
fix some compiler warnings

### DIFF
--- a/src/RemoteDebug.cpp
+++ b/src/RemoteDebug.cpp
@@ -260,7 +260,7 @@ bool RemoteDebug::begin(String hostName, uint16_t port,  uint8_t startingDebugLe
 	if (port != TELNET_PORT) { // Bug: not more can use begin(port)..
 	    return false;
 	}
-	
+
 	TelnetServer.begin();
 	TelnetServer.setNoDelay(true);
 
@@ -1517,7 +1517,7 @@ void RemoteDebug::processCommand() {
 	// Send status to app
 
 	if (_connectedWS) {
-		DebugWS.printf("$app:M:%lu:\n", free);
+		DebugWS.printf("$app:M:%du:\n", free);
 	}
 
 #endif
@@ -1928,7 +1928,7 @@ void RemoteDebug::wsSendInfo() {
 #endif
 
 		DebugWS.println(); // Workaround to not get dirty "[0m" ???
-		DebugWS.printf("$app:V:%s:%s:%c:%lu:%c:N\n", version.c_str(), board.c_str(), features, getFreeMemory(), dbgEnabled);
+		DebugWS.printf("$app:V:%s:%s:%c:%du:%c:N\n", version.c_str(), board.c_str(), features, getFreeMemory(), dbgEnabled);
 
 		// Status of debug level
 

--- a/src/RemoteDebugWS.cpp
+++ b/src/RemoteDebugWS.cpp
@@ -230,8 +230,8 @@ RemoteDebugWS::~RemoteDebugWS() {
 
 void webSocketEvent(uint8_t num, WStype_t type, uint8_t * payload, size_t payloadlength) { // When a WebSocket message is received
 
-	int blk_count = 0;
-	char ipaddr[26];
+	// int blk_count = 0;
+	// char ipaddr[26];
 	IPAddress localip;
 
 	switch (type) {


### PR DESCRIPTION
Fix for the following warnings:

```
.\RemoteDebug\src\RemoteDebug.cpp: In member function 'void RemoteDebug::processCommand()':
.\RemoteDebug\src\RemoteDebug.cpp:1520:39: warning: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'uint32_t {aka unsigned int}' [-Wformat=]
   DebugWS.printf("$app:M:%lu:\n", free);
                                       ^
.\RemoteDebug\src\RemoteDebug.cpp: In member function 'void RemoteDebug::wsSendInfo()':
.\RemoteDebug\src\RemoteDebug.cpp:1931:117: warning: format '%lu' expects argument of type 'long unsigned int', but argument 6 has type 'uint32_t {aka unsigned int}' [-Wformat=]
   DebugWS.printf("$app:V:%s:%s:%c:%lu:%c:N\n", version.c_str(), board.c_str(), features, getFreeMemory(), dbgEnabled);
                                                                                                                     ^
.\RemoteDebug\src\RemoteDebugWS.cpp: In function 'void webSocketEvent(uint8_t, WStype_t, uint8_t*, size_t)':
.\RemoteDebug\src\RemoteDebugWS.cpp:233:6: warning: unused variable 'blk_count' [-Wunused-variable]
  int blk_count = 0;
      ^
.\RemoteDebug\src\RemoteDebugWS.cpp:234:7: warning: unused variable 'ipaddr' [-Wunused-variable]
  char ipaddr[26];
       ^
       
```