### PR TITLE
hwcrypto/sha.h removed in arduino-esp32 v2

### DIFF
--- a/src/utility/WebSockets.cpp
+++ b/src/utility/WebSockets.cpp
@@ -39,7 +39,11 @@ extern "C" {
 #ifdef ESP8266
 #include <Hash.h>
 #elif defined(ESP32)
-#include <hwcrypto/sha.h>
+#ifdef ESP_ARDUINO_VERSION             // defined since arduino-esp32 v2.0.0
+#include <sha/sha_parallel_engine.h>  
+#else
+#include <hwcrypto/sha.h>              // removed in arduino-esp32 v2.0.0
+#endif
 #else
 
 extern "C" {

--- a/src/utility/WebSockets.cpp
+++ b/src/utility/WebSockets.cpp
@@ -39,10 +39,14 @@ extern "C" {
 #ifdef ESP8266
 #include <Hash.h>
 #elif defined(ESP32)
-#ifdef ESP_ARDUINO_VERSION             // defined since arduino-esp32 v2.0.0
+#ifdef ESP_ARDUINO_VERSION                                  // defined since arduino-esp32 v2.0.0
+#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(2, 0, 0) // check version in case ESP_ARDUINO_VERSION is backported to 1.x
 #include <sha/sha_parallel_engine.h>  
 #else
-#include <hwcrypto/sha.h>              // removed in arduino-esp32 v2.0.0
+#include <hwcrypto/sha.h>                                   // removed in arduino-esp32 v2.0.0
+#endif
+#else
+#include <hwcrypto/sha.h>                                   // removed in arduino-esp32 v2.0.0
 #endif
 #else
 


### PR DESCRIPTION
resolve include issue in platformio using espressif32 framework with upstream arduino-esp32 v2.x

hwcrypto/sha.h removed in arduino-esp32 v2.x
<sha/sha_parallel_engine.h> is the drop-in replacement 

Uses version defines added in Arduino framework v2 to determine which import to use.
https://github.com/espressif/arduino-esp32/blob/399f4ecbb3a4cef21e2bffa37adb6190356dfb76/cores/esp32/esp_arduino_version.h#L40